### PR TITLE
Add support for Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,44 @@
-FROM --platform=${BUILDPLATFORM} golang:1.15.7-alpine AS build
+# syntax = docker/dockerfile:1-experimental
+# special thanks to https://github.com/chris-crone/containerized-go-dev
+
+FROM --platform=${BUILDPLATFORM} golang:1.15.7-alpine AS base
 WORKDIR /src
 ENV CGO_ENABLED=0
-COPY . .
+COPY go.* .
+RUN --mount=type=cache,target=/go/pkg/mod \
+    go mod download
+
+FROM base AS build
 ARG TARGETOS
 ARG TARGETARCH
-RUN GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -o /out/agora .
+RUN --mount=target=. \
+    --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -o /out/agora .
+
+FROM base AS unit-test
+RUN --mount=target=. \
+    --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    mkdir /out && go test ./... -v -coverprofile=/out/cover.out ./...
+
+FROM golangci/golangci-lint:v1.31.0-alpine AS lint-base
+
+FROM base AS lint
+RUN --mount=target=. \
+    --mount=from=lint-base,src=/usr/bin/golangci-lint,target=/usr/bin/golangci-lint \
+    --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    --mount=type=cache,target=/root/.cache/golangci-lint \
+    golangci-lint run --timeout 10m0s ./...
+
+FROM scratch AS unit-test-coverage
+COPY --from=unit-test /out/cover.out /cover.out
+
+FROM base AS build-image
+WORKDIR /app
+COPY --from=build /out/agora .
+ENTRYPOINT [ "/app/agora" ]
 
 FROM scratch AS bin-unix
 COPY --from=build /out/agora /

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+LAST_COMMIT_SHA := $(shell git rev-parse --short HEAD)
+
 all: bin/agora
 
 PLATFORM=local
@@ -5,3 +7,22 @@ PLATFORM=local
 .PHONY: bin/agora
 bin/agora:
 	@docker build . --target bin --output bin/ --platform ${PLATFORM}
+
+.PHONY: unit-test
+unit-test:
+	@docker build . --target unit-test
+
+.PHONY: unit-test-coverage
+unit-test-coverage:
+	@docker build . --target unit-test-coverage \
+	--output coverage/
+	cat coverage/cover.out
+
+.PHONY: lint
+lint:
+	@docker build . --target lint
+
+.PHONY: build-image
+build-image:
+	@docker build . --target build-image --platform linux/amd64 \
+	-t agora:$(LAST_COMMIT_SHA) -t agora:latest

--- a/main.go
+++ b/main.go
@@ -1,5 +1,7 @@
 package main
 
-func main() {
+import "fmt"
 
+func main() {
+	fmt.Println("hello")
 }


### PR DESCRIPTION
This PR adds a Dockerfile and Makefile to assist with developing, testing, and creating Docker images.

* The Makefile contains multiple targets including bin/agora, unit-test, unit-test-coverage, lint, and build-image.
    * `bin/agora` supports building a binary file for the Go application for any platform.
    * `unit-test` runs unit tests for the application.
    * `unit-test-coverage` reports coverage information about the unit tests.
    * `lint` reports any style warnings.
    * `build-image` builds a Docker image with the application embedded and tags the image with the `latest` tag along with the SHA of the latest commit on the current branch. 
* The Dockerfile contains the necessary targets to support the targets in the Makefile

Closes #8 