### PR TITLE
Remove config file from docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,6 @@ COPY --from=unit-test /out/cover.out /cover.out
 FROM base AS build-image
 WORKDIR /app
 COPY --from=build /out/agora .
-COPY config/*.yaml .
 ENTRYPOINT [ "/app/agora" ]
 
 FROM scratch AS bin-unix


### PR DESCRIPTION
Reopening from #53 with new base to prevent merge conflicts. 

This PR removes the config file from being embedded within the Docker image. This makes it easier to inject the config file in any environment, including CI/CD.