### PR TITLE
Add health check endpoint

### DIFF
--- a/adapter/health_adapter.go
+++ b/adapter/health_adapter.go
@@ -1,0 +1,13 @@
+package adapter
+
+import (
+	"github.com/jake-hansen/agora/api/dto"
+	"github.com/jake-hansen/agora/domain"
+)
+
+func HealthDomainToDTO(health *domain.Health) *dto.Health {
+	h := &dto.Health{
+		Healthy: health.Healthy,
+	}
+	return h
+}

--- a/api/dto/health.go
+++ b/api/dto/health.go
@@ -1,0 +1,6 @@
+package dto
+
+type Health struct {
+	Healthy bool `json:"healthy"`
+	Reason	string `json:"reason,omitempty"`
+}

--- a/api/handlers/healthhandler/health_handler.go
+++ b/api/handlers/healthhandler/health_handler.go
@@ -1,0 +1,36 @@
+package healthhandler
+
+import (
+	"github.com/gin-gonic/gin"
+	"github.com/jake-hansen/agora/adapter"
+	"github.com/jake-hansen/agora/domain"
+	"net/http"
+)
+
+type HealthHandler struct {
+	healthService *domain.HealthService
+}
+
+func (h *HealthHandler) Register(parentGroup *gin.RouterGroup) error {
+	healthGroup := parentGroup.Group("health")
+	{
+		healthGroup.GET("", h.GetHealth)
+	}
+	return nil
+}
+
+func (h *HealthHandler) GetHealth(c *gin.Context) {
+	health, err := (*h.healthService).GetHealth()
+
+	if err != nil {
+		_ = c.Error(err).SetType(gin.ErrorTypePublic)
+		return
+	} else {
+		if health.Healthy {
+			c.JSON(http.StatusOK, adapter.HealthDomainToDTO(health))
+		} else {
+			c.JSON(http.StatusServiceUnavailable, adapter.HealthDomainToDTO(health))
+		}
+	}
+}
+

--- a/api/handlers/healthhandler/provider.go
+++ b/api/handlers/healthhandler/provider.go
@@ -1,0 +1,7 @@
+package healthhandler
+
+import "github.com/jake-hansen/agora/domain"
+
+func Provide(healthService domain.HealthService) *HealthHandler {
+	return &HealthHandler{healthService: &healthService}
+}

--- a/api/handlers/provider.go
+++ b/api/handlers/provider.go
@@ -3,13 +3,16 @@ package handlers
 import (
 	"github.com/google/wire"
 	"github.com/jake-hansen/agora/api/handlers/authhandler"
+	"github.com/jake-hansen/agora/api/handlers/healthhandler"
 	"github.com/jake-hansen/agora/api/handlers/meetingplatformhandler"
 	"github.com/jake-hansen/agora/api/handlers/userhandler"
 	"github.com/jake-hansen/agora/api/middleware/authmiddleware"
 	"github.com/jake-hansen/agora/database/repositories/meetingplatformrepo"
 	"github.com/jake-hansen/agora/database/repositories/oauthinforepo"
+	"github.com/jake-hansen/agora/database/repositories/schemamigrationrepo"
 	"github.com/jake-hansen/agora/database/repositories/userrepo"
 	"github.com/jake-hansen/agora/router/handlers"
+	"github.com/jake-hansen/agora/services/healthservice"
 	"github.com/jake-hansen/agora/services/jwtservice"
 	"github.com/jake-hansen/agora/services/meetingplatforms"
 	"github.com/jake-hansen/agora/services/meetingplatformservice"
@@ -19,14 +22,17 @@ import (
 )
 
 // ProvideAllProductionHandlers provides all the handlers that will be used in production.
-func ProvideAllProductionHandlers(auth *authhandler.AuthHandler, user *userhandler.UserHandler,
-		meetingProvider *meetingplatformhandler.MeetingPlatformHandler) *[]handlers.Handler {
+func ProvideAllProductionHandlers(auth *authhandler.AuthHandler,
+		user *userhandler.UserHandler,
+		meetingProvider *meetingplatformhandler.MeetingPlatformHandler,
+		healthHandler *healthhandler.HealthHandler) *[]handlers.Handler {
 
 	var handlers []handlers.Handler
 
 	handlers = append(handlers, auth)
 	handlers = append(handlers, user)
 	handlers = append(handlers, meetingProvider)
+	handlers = append(handlers, healthHandler)
 
 	return &handlers
 }
@@ -36,19 +42,22 @@ var (
 		meetingplatformservice.ProviderSet,
 		jwtservice.ProviderProductionSet,
 		oauthinfoservice.ProviderProductionSet,
-		userservice.ProviderProductionSet)
+		userservice.ProviderProductionSet,
+		healthservice.ProviderProductionSet)
 
 	repos = wire.NewSet(meetingplatformrepo.ProviderSet,
 		meetingplatforms.ProviderSet,
 		userrepo.ProviderProductionSet,
-		oauthinforepo.ProviderSet)
+		oauthinforepo.ProviderSet,
+		schemamigrationrepo.ProviderProductionSet)
 
 	middleware = wire.NewSet(authmiddleware.Provide,
 		authmiddleware.ProvideAuthorizationHeaderParser)
 
 	handlersSet = wire.NewSet(authhandler.Provide,
 		userhandler.Provide,
-		meetingplatformhandler.Provide)
+		meetingplatformhandler.Provide,
+		healthhandler.Provide)
 
 	// ProviderProductionSet provides all handlers for production.
 	ProviderProductionSet = wire.NewSet(ProvideAllProductionHandlers, repos, services, middleware, handlersSet)

--- a/database/repositories/schemamigrationrepo/provider.go
+++ b/database/repositories/schemamigrationrepo/provider.go
@@ -1,0 +1,15 @@
+package schemamigrationrepo
+
+import (
+	"github.com/google/wire"
+	"github.com/jake-hansen/agora/database"
+	"github.com/jake-hansen/agora/domain"
+)
+
+func Provide(manager *database.Manager) *SchemaMigrationRepo {
+	return &SchemaMigrationRepo{DB: manager.DB}
+}
+
+var (
+	ProviderProductionSet = wire.NewSet(Provide, wire.Bind(new(domain.SchemaMigrationRepo), new(*SchemaMigrationRepo)))
+)

--- a/database/repositories/schemamigrationrepo/schema_migration_repo.go
+++ b/database/repositories/schemamigrationrepo/schema_migration_repo.go
@@ -1,0 +1,21 @@
+package schemamigrationrepo
+
+import (
+	"fmt"
+	"github.com/jake-hansen/agora/domain"
+	"gorm.io/gorm"
+)
+
+type SchemaMigrationRepo struct {
+	DB *gorm.DB
+}
+
+func (s *SchemaMigrationRepo) GetSchemaMigrationByVersion(version int) (migration *domain.SchemaMigration, err error) {
+	m := new(domain.SchemaMigration)
+	if err := s.DB.First(m, version).Error; err != nil {
+		return nil, fmt.Errorf("error retrieving schema migration with version %d: %w", version, err)
+	}
+	return m, nil
+}
+
+

--- a/domain/health.go
+++ b/domain/health.go
@@ -1,0 +1,19 @@
+package domain
+
+type Health struct {
+	Healthy	bool
+	Reason	string
+}
+
+type SchemaMigration struct {
+	Version	int
+	Dirty	int
+}
+
+type HealthService interface {
+	GetHealth() (*Health, error)
+}
+
+type SchemaMigrationRepo interface {
+	GetSchemaMigrationByVersion(version int) (*SchemaMigration, error)
+}

--- a/services/healthservice/health_service.go
+++ b/services/healthservice/health_service.go
@@ -1,0 +1,32 @@
+package healthservice
+
+import (
+	"errors"
+	"fmt"
+	"github.com/jake-hansen/agora/domain"
+	"gorm.io/gorm"
+)
+
+var neededSchemaVersion = 7
+
+type HealthService struct {
+	schemaRepo *domain.SchemaMigrationRepo
+}
+
+func (h *HealthService) GetHealth() (*domain.Health, error) {
+	health := &domain.Health{Healthy: false}
+
+	_, err := (*h.schemaRepo).GetSchemaMigrationByVersion(neededSchemaVersion)
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			health.Reason = fmt.Sprintf("database version is not at needed version %d", neededSchemaVersion)
+		} else {
+			return nil, err
+		}
+	} else {
+		health.Healthy = true
+	}
+
+	return health, nil
+}
+

--- a/services/healthservice/provider.go
+++ b/services/healthservice/provider.go
@@ -1,0 +1,14 @@
+package healthservice
+
+import (
+	"github.com/google/wire"
+	"github.com/jake-hansen/agora/domain"
+)
+
+func Provide(repository domain.SchemaMigrationRepo) *HealthService {
+	return &HealthService{schemaRepo: &repository}
+}
+
+var (
+	ProviderProductionSet = wire.NewSet(Provide, wire.Bind(new(domain.HealthService), new(*HealthService)))
+)


### PR DESCRIPTION
This PR adds the endpoint `/v1/health` which reports back the health of the application. The application is considered healthy if the database schema's version matches the needed version in `health_service.go`. This helps automated deployment tools determine if a container of the application can begin processing requests.

Note that whenever a new migration is made, the `neededSchemaVersion` variable in `health_service.go` will need to be updated to the needed version.