### PR TITLE
Add curl to Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@
 # special thanks to https://github.com/chris-crone/containerized-go-dev
 
 FROM --platform=${BUILDPLATFORM} golang:1.15.7-alpine AS base
+RUN apk --no-cache add curl
 WORKDIR /src
 ENV CGO_ENABLED=0
 COPY go.* .


### PR DESCRIPTION
Curl can be used to support health checks on containers.