### PR TITLE
Fix same site cookie bug

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -24,7 +24,7 @@ api:
       allowed:
 # This is the environment the application should run in. This controls
 # various things but mainly logging levels. Valid values for this property
-# are 'dev' or 'prod'.
+# are 'dev', 'prod', or 'staging'.
 environment:
 jwtservice:
   # This is the duration of the JWT token that is issued when using the 

--- a/services/cookieservice/cookie_service.go
+++ b/services/cookieservice/cookie_service.go
@@ -1,6 +1,9 @@
 package cookieservice
 
-import "github.com/gin-gonic/gin"
+import (
+	"github.com/gin-gonic/gin"
+	"net/http"
+)
 
 type CookieService struct {
 	Cfg Config
@@ -9,6 +12,7 @@ type CookieService struct {
 type Config struct {
 	Domain	string
 	SecureCookies bool
+	SameSite http.SameSite
 }
 
 func NewCookieService(cfg Config) *CookieService {
@@ -18,5 +22,6 @@ func NewCookieService(cfg Config) *CookieService {
 }
 
 func (c *CookieService) SetCookie(g *gin.Context, name string, value string, maxAge int, path string, httpOnly bool) {
+	g.SetSameSite(c.Cfg.SameSite)
 	g.SetCookie(name, value, maxAge, path, c.Cfg.Domain, c.Cfg.SecureCookies, httpOnly)
 }

--- a/services/cookieservice/provider.go
+++ b/services/cookieservice/provider.go
@@ -4,17 +4,25 @@ import (
 	"github.com/google/wire"
 	"github.com/jake-hansen/agora/domain"
 	"github.com/spf13/viper"
+	"net/http"
 )
 
 func Cfg(v *viper.Viper) *Config {
 	domain:= v.GetString("api.domain")
 	env := v.GetString("environment")
 
-	secureCookies := env == "prod"
+	prodOrStaging := env == "prod" || env == "staging"
+
+	secureCookies := prodOrStaging
 
 	cfg := &Config{
 		Domain: domain,
 		SecureCookies: secureCookies,
+		SameSite: http.SameSiteLaxMode,
+	}
+
+	if prodOrStaging {
+		cfg.SameSite = http.SameSiteNoneMode
 	}
 
 	return cfg


### PR DESCRIPTION
This PR fixes a bug where cookies did not have the same-site attribute set which prevented them from being saved during CORS requests.

In the dev environment, all cookies' same-site attribute will be set to 'LAX' and they will NOT be secure.

In prod or staging, all cookies' same-site attribute will be set to 'NONE' and they will be secure.

'staging' is now also considered a valid environment.