### PR TITLE
Fix Webex instant meeting bug

### DIFF
--- a/platforms/webex/webexadapter/meeting_adapter.go
+++ b/platforms/webex/webexadapter/meeting_adapter.go
@@ -11,7 +11,16 @@ func DomainMeetingToWebexMeeting(meeting domain.Meeting) *webexdomain.Meeting {
 	if meeting.Type == domain.TypeInstant {
 		meeting.StartTime = time.Now().Add(time.Second * 30)
 		meeting.Duration = time.Minute * 30
+
+		if meeting.Description == "" {
+			meeting.Description = "Instant meeting"
+		}
+
+		if meeting.Title == "" {
+			meeting.Title = "Instant meeting"
+		}
 	}
+
 	endTime := meeting.StartTime.Add(meeting.Duration)
 
 	webex := &webexdomain.Meeting{


### PR DESCRIPTION
This PR fixes a bug where instant meetings created with Webex would fail to be created if a title and description were not provided.

In the instance that a title or description are not provided, a default value will be set instead. 