### PR TITLE
Add ability to get single invite

### DIFF
--- a/api/handlers/invitehandler/invite_handler.go
+++ b/api/handlers/invitehandler/invite_handler.go
@@ -227,7 +227,7 @@ func (i *InviteHandler) GetInvite(c *gin.Context) {
 		return
 	}
 
-	if invite.InviterID != user.ID {
+	if invite.InviterID != user.ID || invite.InviteeID != user.ID {
 		err = errors.New("cannot get invite created by another user")
 		apiErr := api.NewAPIError(http.StatusNotFound, err, fmt.Sprintf("invite with id %s not found", inviteIDParam))
 		_ = c.Error(apiErr).SetType(gin.ErrorTypePublic)


### PR DESCRIPTION
This PR adds the endpoint `/v1/invites/:id` to retrieve a single invite.

Users can only retrieve an invite that they created or are an invitee of.