### PR TITLE
Fix trailing slash on user endpoint

### DIFF
--- a/api/handlers/userhandler/user_handler.go
+++ b/api/handlers/userhandler/user_handler.go
@@ -26,7 +26,7 @@ func (u *UserHandler) Register(parentGroup *gin.RouterGroup) error {
 	{
 		userGroup.POST("", u.RegisterUser)
 		userGroup.GET("/:id", u.GetUser)
-		userGroup.GET("/", u.SearchUsers)
+		userGroup.GET("", u.SearchUsers)
 	}
 	return nil
 }


### PR DESCRIPTION
This PR removes the trailing slash on the search users endpoint.