### PR TITLE
Fix meeting retrieval bug

### DIFF
--- a/api/handlers/meetinghandler/meeting_handler.go
+++ b/api/handlers/meetinghandler/meeting_handler.go
@@ -62,7 +62,7 @@ func (m *MeetingHandler) Register(parentGroup *gin.RouterGroup) error {
 	{
 		meetingHandlerGroup.POST("/:id/platforms/:platform/meetings", m.CreateMeeting)
 		meetingHandlerGroup.GET("/:id/platforms/:platform/meetings", m.GetMeetings)
-		meetingHandlerGroup.GET("/:id/platforms/:platform/meetings/:id", m.GetMeeting)
+		meetingHandlerGroup.GET("/:userid/platforms/:platform/meetings/:id", m.GetMeeting)
 		meetingHandlerGroup.DELETE("/:userid/platforms/:platform/meetings/:id", m.DeleteMeeting)
 	}
 


### PR DESCRIPTION
This PR fixes a bug where meetings were not able to be retrieved through the get meeting endpoint due to a bug with the naming of parameters. 